### PR TITLE
Use correct array size in polygonToCellsExperimental

### DIFF
--- a/Sources/CH3/h3api_ext.c
+++ b/Sources/CH3/h3api_ext.c
@@ -27,6 +27,12 @@ H3Error maxPolygonToCellsSizeSimple(const LatLng* verts, int numVerts, int res, 
     return maxPolygonToCellsSize(&polygon, res, flags, out);
 }
 
+H3Error maxPolygonToCellsSizeExperimentalSimple(const LatLng* verts, int numVerts, int res, uint32_t flags, int64_t* out) {
+    GeoLoop loop = { .numVerts = numVerts, .verts = (LatLng*)verts };
+    GeoPolygon polygon = { .geoloop = loop, .numHoles = 0, .holes = NULL };
+    return maxPolygonToCellsSizeExperimental(&polygon, res, flags, out);
+}
+
 H3Error polygonToCellsExperimentalSimple(
     const LatLng* verts,
     int numVerts,

--- a/Sources/CH3/include/h3api_ext.h
+++ b/Sources/CH3/include/h3api_ext.h
@@ -14,6 +14,7 @@ H3Error polygonToCellsExperimentalSimple(
     int64_t size,
     H3Index* out
 );
+H3Error maxPolygonToCellsSizeExperimentalSimple(const LatLng* verts, int numVerts, int res, uint32_t flags, int64_t* out);
 int cellsToPolygonFlat(
     const H3Index* cells,
     int numCells,

--- a/Sources/H3/H3.Regions.swift
+++ b/Sources/H3/H3.Regions.swift
@@ -66,7 +66,7 @@ public func polygonToCellsExperimental(
     // Get max size first
     var maxSize: Int64 = 0
     let sizeErr = latLngs.withUnsafeBufferPointer { buf in
-        CH3.maxPolygonToCellsSizeSimple(buf.baseAddress, Int32(buf.count), Int32(resolution), containmentMode.rawValue, &maxSize)
+        CH3.maxPolygonToCellsSizeExperimentalSimple(buf.baseAddress, Int32(buf.count), Int32(resolution), containmentMode.rawValue, &maxSize)
     }
     precondition(sizeErr == 0, "maxPolygonToCellsSize failed")
 
@@ -87,6 +87,24 @@ public func polygonToCellsExperimental(
     precondition(err == 0, "polygonToCellsExperimental failed")
     
     return output.filter { $0 != 0 }
+}
+
+public func maxPolygonToCellsSizeExperimental(
+    boundary: [CLLocationCoordinate2D],
+    resolution: Int,
+    flags: UInt32
+) -> Int {
+    let latLngs = boundary.map {
+        LatLng(lat: CH3.degsToRads($0.latitude), lng: CH3.degsToRads($0.longitude))
+    }
+
+    var size: Int64 = 0
+    let err = latLngs.withUnsafeBufferPointer { buf in
+        CH3.maxPolygonToCellsSizeExperimentalSimple(buf.baseAddress, Int32(buf.count), Int32(resolution), flags, &size)
+    }
+    precondition(err == 0 && size >= 0, "maxPolygonToCellsSize failed with error \(err)")
+    
+    return Int(size)
 }
 
 public func cellsToLinkedMultiPolygon(cells: [UInt64]) -> [LatLng] {


### PR DESCRIPTION
Implementation of the `maxPolygonToCellsSizeExperimental` function and using it instead of `maxPolygonToCellsSize` to calculate the max size of the array when calling `polygonToCellsExperimental`. This ensures none of cells are skipped in `overlapping` and `overlappingBoundingBox` containment modes.