### PR TITLE
Add H3ErrorCode

### DIFF
--- a/Sources/H3/H3.DirectedEdges.swift
+++ b/Sources/H3/H3.DirectedEdges.swift
@@ -1,17 +1,19 @@
 import CH3
 
-public func areNeighborCells(a: UInt64, b: UInt64) -> Bool {
+public func areNeighborCells(a: UInt64, b: UInt64) throws -> Bool {
     var isNeighbor: Int32 = 0
     let err = CH3.areNeighborCells(a, b, &isNeighbor)
-    precondition(err == 0, "areNeighborCells failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return isNeighbor != 0
 }
 
-public func cellsToDirectedEdge(origin: UInt64, destination: UInt64) -> UInt64 {
+public func cellsToDirectedEdge(origin: UInt64, destination: UInt64) throws
+    -> UInt64
+{
     var edge: UInt64 = 0
     let err = CH3.cellsToDirectedEdge(origin, destination, &edge)
-    precondition(err == 0, "cellsToDirectedEdge failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return edge
 }
@@ -20,46 +22,48 @@ public func isValidDirectedEdge(edge: UInt64) -> Bool {
     return CH3.isValidDirectedEdge(edge) != 0
 }
 
-public func getDirectedEdgeOrigin(edge: UInt64) -> UInt64 {
+public func getDirectedEdgeOrigin(edge: UInt64) throws -> UInt64 {
     var origin: UInt64 = 0
     let err = CH3.getDirectedEdgeOrigin(edge, &origin)
-    precondition(err == 0, "getDirectedEdgeOrigin failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return origin
 }
 
-public func getDirectedEdgeDestination(edge: UInt64) -> UInt64 {
+public func getDirectedEdgeDestination(edge: UInt64) throws -> UInt64 {
     var destination: UInt64 = 0
     let err = CH3.getDirectedEdgeDestination(edge, &destination)
-    precondition(err == 0, "getDirectedEdgeDestination failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return destination
 }
 
-public func directedEdgeToCells(edge: UInt64) -> (origin: UInt64, destination: UInt64) {
+public func directedEdgeToCells(edge: UInt64) throws -> (
+    origin: UInt64, destination: UInt64
+) {
     var buffer = [UInt64](repeating: 0, count: 2)
     let err = buffer.withUnsafeMutableBufferPointer {
         CH3.directedEdgeToCells(edge, $0.baseAddress)
     }
-    precondition(err == 0, "directedEdgeToCells failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return (origin: buffer[0], destination: buffer[1])
 }
 
-public func originToDirectedEdges(origin: UInt64) -> [UInt64] {
+public func originToDirectedEdges(origin: UInt64) throws -> [UInt64] {
     var edges = [UInt64](repeating: 0, count: 6)
     let err = edges.withUnsafeMutableBufferPointer {
         CH3.originToDirectedEdges(origin, $0.baseAddress)
     }
-    precondition(err == 0, "originToDirectedEdges failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return edges.filter { $0 != 0 }
 }
 
-public func directedEdgeBoundary(edge: UInt64) -> [LatLng] {
+public func directedEdgeBoundary(edge: UInt64) throws -> [LatLng] {
     var boundary = CellBoundary()
     let err = CH3.directedEdgeToBoundary(edge, &boundary)
-    precondition(err == 0, "directedEdgeToBoundary failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     let coords = withUnsafeBytes(of: &boundary.verts) { raw -> [LatLng] in
         let buffer = raw.bindMemory(to: LatLng.self)
@@ -68,7 +72,3 @@ public func directedEdgeBoundary(edge: UInt64) -> [LatLng] {
 
     return coords
 }
-
-
-
-

--- a/Sources/H3/H3.Errors.swift
+++ b/Sources/H3/H3.Errors.swift
@@ -1,0 +1,106 @@
+import CH3
+
+public enum H3ErrorCode: Error {
+    case Failed
+    case Domain
+    case LatLngDomain
+    case ResDomain
+    case CellInvalid
+    case DirEdgeInvalid
+    case UndirEdgeInvalid
+    case VertexInvalid
+    case Pentagon
+    case DuplicateInput
+    case NotNeighbors
+    case ResMismatch
+    case MemoryAlloc
+    case MemoryBounds
+    case OptionInvalid
+
+    // Additional error when size is invalid
+    case SizeInvalid
+
+    static func fromH3(_ code: UInt32) -> Error {
+        switch code {
+        case E_SUCCESS.rawValue:
+            fatalError("Cannot create error from success code")
+        case E_FAILED.rawValue:
+            return H3ErrorCode.Failed
+        case E_DOMAIN.rawValue:
+            return H3ErrorCode.Domain
+        case E_LATLNG_DOMAIN.rawValue:
+            return H3ErrorCode.LatLngDomain
+        case E_RES_DOMAIN.rawValue:
+            return H3ErrorCode.ResDomain
+        case E_CELL_INVALID.rawValue:
+            return H3ErrorCode.CellInvalid
+        case E_DIR_EDGE_INVALID.rawValue:
+            return H3ErrorCode.DirEdgeInvalid
+        case E_UNDIR_EDGE_INVALID.rawValue:
+            return H3ErrorCode.UndirEdgeInvalid
+        case E_VERTEX_INVALID.rawValue:
+            return H3ErrorCode.VertexInvalid
+        case E_PENTAGON.rawValue:
+            return H3ErrorCode.Pentagon
+        case E_DUPLICATE_INPUT.rawValue:
+            return H3ErrorCode.DuplicateInput
+        case E_NOT_NEIGHBORS.rawValue:
+            return H3ErrorCode.NotNeighbors
+        case E_RES_MISMATCH.rawValue:
+            return H3ErrorCode.ResMismatch
+        case E_MEMORY_ALLOC.rawValue:
+            return H3ErrorCode.MemoryAlloc
+        case E_MEMORY_BOUNDS.rawValue:
+            return H3ErrorCode.MemoryBounds
+        case E_OPTION_INVALID.rawValue:
+            return H3ErrorCode.OptionInvalid
+        default:
+            fatalError("Unhandled error code: \(code)")
+        }
+    }
+
+    static func throwOnError(_ code: UInt32) throws {
+        if code != E_SUCCESS.rawValue {
+            throw H3ErrorCode.fromH3(code)
+        }
+    }
+}
+
+extension H3ErrorCode: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .Failed:
+            return
+                "The operation failed but a more specific error is not available"
+        case .Domain:
+            return
+                "Argument was outside of acceptable range (when a more specific error code is not available)"
+        case .LatLngDomain:
+            return
+                "Latitude or longitude arguments were outside of acceptable range"
+        case .ResDomain:
+            return "Resolution argument was outside of acceptable range"
+        case .CellInvalid: return "`H3Index` cell argument was not valid"
+        case .DirEdgeInvalid:
+            return "`H3Index` directed edge argument was not valid"
+        case .UndirEdgeInvalid:
+            return "`H3Index` undirected edge argument was not valid"
+        case .VertexInvalid: return "`H3Index` vertex argument was not valid"
+        case .Pentagon:
+            return
+                "Pentagon distortion was encountered which the algorithm could not handle it"
+        case .DuplicateInput:
+            return
+                "Duplicate input was encountered in the arguments and the algorithm could not handle it"
+        case .NotNeighbors: return "`H3Index` cell arguments were not neighbors"
+        case .ResMismatch:
+            return "`H3Index` cell arguments had incompatible resolutions"
+        case .MemoryAlloc: return "Necessary memory allocation failed"
+        case .MemoryBounds:
+            return "Bounds of provided memory were not large enough"
+        case .OptionInvalid: return "Mode or flags argument was not valid."
+        default:
+            fatalError("No description available for unrecognized error")
+        }
+    }
+}

--- a/Sources/H3/H3.Hierarchy.swift
+++ b/Sources/H3/H3.Hierarchy.swift
@@ -1,72 +1,85 @@
 import CH3
 
-public func cellToParent(cell: UInt64, resolution: Int) -> UInt64 {
+public func cellToParent(cell: UInt64, resolution: Int) throws -> UInt64 {
     var parent: UInt64 = 0
     let err = CH3.cellToParent(cell, Int32(resolution), &parent)
-    precondition(err == 0, "cellToParent failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return parent
 }
 
-public func cellToChildren(cell: UInt64, childResolution: Int) -> [UInt64] {
-    let count = cellToChildrenSize(cell: cell, childResolution: childResolution)
+public func cellToChildren(cell: UInt64, childResolution: Int) throws
+    -> [UInt64]
+{
+    let count = try cellToChildrenSize(
+        cell: cell, childResolution: childResolution)
     var output = [UInt64](repeating: 0, count: Int(count))
 
     let err = output.withUnsafeMutableBufferPointer {
         CH3.cellToChildren(cell, Int32(childResolution), $0.baseAddress)
     }
-    precondition(err == 0, "cellToChildren failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return output
 }
 
-public func cellToChildrenSize(cell: UInt64, childResolution: Int) -> Int64 {
+public func cellToChildrenSize(cell: UInt64, childResolution: Int) throws
+    -> Int64
+{
     var size: Int64 = 0
     let err = CH3.cellToChildrenSize(cell, Int32(childResolution), &size)
-    precondition(err == 0, "cellToChildrenSize failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return size
 }
 
-public func cellToCenterChild(cell: UInt64, childResolution: Int) -> UInt64 {
+public func cellToCenterChild(cell: UInt64, childResolution: Int) throws
+    -> UInt64
+{
     var result: UInt64 = 0
     let err = CH3.cellToCenterChild(cell, Int32(childResolution), &result)
-    precondition(err == 0, "cellToCenterChild failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return result
 }
 
-public func cellToChildPos(child: UInt64, parentResolution: Int) -> Int64 {
+public func cellToChildPos(child: UInt64, parentResolution: Int) throws -> Int64
+{
     var pos: Int64 = 0
     let err = CH3.cellToChildPos(child, Int32(parentResolution), &pos)
-    precondition(err == 0, "cellToChildPos failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return pos
 }
 
-public func childPosToCell(position: Int64, parent: UInt64, childResolution: Int) -> UInt64 {
+public func childPosToCell(
+    position: Int64, parent: UInt64, childResolution: Int
+) throws -> UInt64 {
     var result: UInt64 = 0
-    let err = CH3.childPosToCell(position, parent, Int32(childResolution), &result)
-    precondition(err == 0, "childPosToCell failed with error \(err)")
+    let err = CH3.childPosToCell(
+        position, parent, Int32(childResolution), &result)
+    try H3ErrorCode.throwOnError(err)
 
     return result
 }
 
-public func compact(cells: [UInt64]) -> [UInt64] {
+public func compact(cells: [UInt64]) throws -> [UInt64] {
     var compacted = [UInt64](repeating: 0, count: cells.count)
 
     let err = cells.withUnsafeBufferPointer { inputBuf in
         compacted.withUnsafeMutableBufferPointer { outputBuf in
-            CH3.compactCells(inputBuf.baseAddress, outputBuf.baseAddress, Int64(cells.count))
+            CH3.compactCells(
+                inputBuf.baseAddress, outputBuf.baseAddress, Int64(cells.count))
         }
     }
-    precondition(err == 0, "compactCells failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return compacted.filter { $0 != 0 }
 }
 
-public func uncompact(compacted: [UInt64], resolution: Int) -> [UInt64] {
-    let maxSize = uncompactCellsSize(compacted: compacted, resolution: resolution)
+public func uncompact(compacted: [UInt64], resolution: Int) throws -> [UInt64] {
+    let maxSize = try uncompactCellsSize(
+        compacted: compacted, resolution: resolution)
     var result = [UInt64](repeating: 0, count: maxSize)
 
     let err = compacted.withUnsafeBufferPointer { inputBuf in
@@ -80,18 +93,24 @@ public func uncompact(compacted: [UInt64], resolution: Int) -> [UInt64] {
             )
         }
     }
-    precondition(err == 0, "uncompactCells failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return result.filter { $0 != 0 }
 }
 
-public func uncompactCellsSize(compacted: [UInt64], resolution: Int) -> Int {
+public func uncompactCellsSize(compacted: [UInt64], resolution: Int) throws
+    -> Int
+{
     var size: Int64 = 0
 
     let err = compacted.withUnsafeBufferPointer {
-        CH3.uncompactCellsSize($0.baseAddress, Int64(compacted.count), Int32(resolution), &size)
+        CH3.uncompactCellsSize(
+            $0.baseAddress, Int64(compacted.count), Int32(resolution), &size)
     }
-    precondition(err == 0 && size >= 0, "uncompactCellsSize failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+    if size < 0 {
+        throw H3ErrorCode.SizeInvalid
+    }
+
     return Int(size)
 }

--- a/Sources/H3/H3.Indexing.swift
+++ b/Sources/H3/H3.Indexing.swift
@@ -1,29 +1,34 @@
 import CH3
 
-public func latLngToCell(latitude: Double, longitude: Double, resolution: Int) -> UInt64 {
-    var coords = CH3.LatLng(lat: CH3.degsToRads(latitude), lng: CH3.degsToRads(longitude))
+public func latLngToCell(latitude: Double, longitude: Double, resolution: Int)
+    throws -> UInt64
+{
+    var coords = CH3.LatLng(
+        lat: CH3.degsToRads(latitude), lng: CH3.degsToRads(longitude))
     var index: H3Index = 0
     let error = CH3.latLngToCell(&coords, Int32(resolution), &index)
-    precondition(error == 0, "latLngToCell failed with error code \(error)")
+    try H3ErrorCode.throwOnError(error)
 
     return index
 }
 
-public func cellToLatLng(cell: UInt64) -> (latitude: Double, longitude: Double) {
+public func cellToLatLng(cell: UInt64) throws -> (
+    latitude: Double, longitude: Double
+) {
     var coords = LatLng(lat: 0, lng: 0)
     let error = CH3.cellToLatLng(cell, &coords)
-    precondition(error == 0, "cellToLatLng failed with error code \(error)")
-    
+    try H3ErrorCode.throwOnError(error)
+
     let latDeg = CH3.radsToDegs(coords.lat)
     let lngDeg = CH3.radsToDegs(coords.lng)
     return (latitude: latDeg, longitude: lngDeg)
 }
 
-public func cellToBoundary(cell: UInt64) -> [CH3.LatLng] {
+public func cellToBoundary(cell: UInt64) throws -> [CH3.LatLng] {
     var boundary = CellBoundary()
     let err = CH3.cellToBoundary(cell, &boundary)
-    precondition(err == 0, "cellToBoundary failed")
-    
+    try H3ErrorCode.throwOnError(err)
+
     let coords = withUnsafeBytes(of: &boundary.verts) { raw -> [LatLng] in
         let buffer = raw.bindMemory(to: LatLng.self)
         var result = Array(buffer.prefix(Int(boundary.numVerts)))

--- a/Sources/H3/H3.Inspection.swift
+++ b/Sources/H3/H3.Inspection.swift
@@ -8,22 +8,23 @@ public func getBaseCellNumber(cell: UInt64) -> Int32 {
     return CH3.getBaseCellNumber(cell)
 }
 
-public func stringToH3(cellAsString: String) -> UInt64 {
+public func stringToH3(cellAsString: String) throws -> UInt64 {
     var index: H3Index = 0
-    let error = cellAsString.utf8CString.withUnsafeBufferPointer { buf -> H3Error in
+    let error = cellAsString.utf8CString.withUnsafeBufferPointer {
+        buf -> H3Error in
         CH3.stringToH3(buf.baseAddress, &index)
     }
-    precondition(error == 0, "stringToH3 failed with error code \(error)")
+    try H3ErrorCode.throwOnError(error)
 
     return index
 }
 
 private var bufferSize = 17
 
-public func h3ToString(cell: UInt64) -> String {
+public func h3ToString(cell: UInt64) throws -> String {
     var cString = [CChar](repeating: 0, count: bufferSize)
     let error = CH3.h3ToString(cell, &cString, bufferSize)
-    precondition(error == 0, "h3ToString failed with error code \(error)")
+    try H3ErrorCode.throwOnError(error)
 
     return String(cString: cString)
 }
@@ -40,21 +41,24 @@ public func isPentagon(cell: UInt64) -> Bool {
     return CH3.isPentagon(cell) != 0
 }
 
-public func getIcosahedronFaces(cell: UInt64) -> [Int] {
+public func getIcosahedronFaces(cell: UInt64) throws -> [Int] {
     var count: Int32 = 0
     let maxFaceCountErr = CH3.maxFaceCount(cell, &count)
-    precondition(maxFaceCountErr == 0 && count > 0, "maxFaceCount failed")
+    try H3ErrorCode.throwOnError(maxFaceCountErr)
+    if count < 0 {
+        throw H3ErrorCode.SizeInvalid
+    }
 
     var output = [Int32](repeating: -1, count: Int(count))
     let err = CH3.getIcosahedronFaces(cell, &output)
-    precondition(err == 0, "getIcosahedronFaces failed")
+    try H3ErrorCode.throwOnError(err)
 
     return output.filter { $0 != -1 }.map(Int.init)
 }
 
-public func maxFaceCount(cell: UInt64) -> Int {
+public func maxFaceCount(cell: UInt64) throws -> Int {
     var faceCount: Int32 = 0
     let err = CH3.maxFaceCount(cell, &faceCount)
-    precondition(err == 0, "maxFaceCount failed")
+    try H3ErrorCode.throwOnError(err)
     return Int(faceCount)
 }

--- a/Sources/H3/H3.Miscellaneous.swift
+++ b/Sources/H3/H3.Miscellaneous.swift
@@ -8,124 +8,124 @@ public func radsToDegs(radians: Double) -> Double {
     return CH3.radsToDegs(radians)
 }
 
-public func getHexagonAreaAvgKm2(res: Int32) -> Double {
+public func getHexagonAreaAvgKm2(res: Int32) throws -> Double {
     var area: Double = 0
     let err = CH3.getHexagonAreaAvgKm2(res, &area)
-    precondition(err == 0, "getHexagonAreaAvgKm2 failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return area
 }
 
-public func getHexagonAreaAvgM2(res: Int32) -> Double {
+public func getHexagonAreaAvgM2(res: Int32) throws -> Double {
     var area: Double = 0
     let err = CH3.getHexagonAreaAvgM2(res, &area)
-    precondition(err == 0, "getHexagonAreaAvgM2 failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return area
 }
 
-public func cellAreaRads2(cell: UInt64) -> Double {
+public func cellAreaRads2(cell: UInt64) throws -> Double {
     var area: Double = 0
     let err = CH3.cellAreaRads2(cell, &area)
-    precondition(err == 0, "cellAreaRads2 failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return area
 }
 
-public func cellAreaKm2(cell: UInt64) -> Double {
+public func cellAreaKm2(cell: UInt64) throws -> Double {
     var area: Double = 0
     let err = CH3.cellAreaKm2(cell, &area)
-    precondition(err == 0, "cellAreaKm2 failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return area
 }
 
-public func cellAreaM2(cell: UInt64) -> Double {
+public func cellAreaM2(cell: UInt64) throws -> Double {
     var area: Double = 0
     let err = CH3.cellAreaM2(cell, &area)
-    precondition(err == 0, "cellAreaM2 failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return area
 }
 
-public func getHexagonEdgeLengthAvgKm(res: Int32) -> Double {
+public func getHexagonEdgeLengthAvgKm(res: Int32) throws -> Double {
     var length: Double = 0
     let err = CH3.getHexagonEdgeLengthAvgKm(res, &length)
-    precondition(err == 0, "getHexagonEdgeLengthAvgKm failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return length
 }
 
-public func getHexagonEdgeLengthAvgM(res: Int32) -> Double {
+public func getHexagonEdgeLengthAvgM(res: Int32) throws -> Double {
     var length: Double = 0
     let err = CH3.getHexagonEdgeLengthAvgM(res, &length)
-    precondition(err == 0, "getHexagonEdgeLengthAvgM failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return length
 }
 
-public func edgeLengthKm(edge: UInt64) -> Double {
+public func edgeLengthKm(edge: UInt64) throws -> Double {
     var length: Double = 0
     let err = CH3.edgeLengthKm(edge, &length)
-    precondition(err == 0, "edgeLengthKm failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return length
 }
 
-public func edgeLengthM(edge: UInt64) -> Double {
+public func edgeLengthM(edge: UInt64) throws -> Double {
     var length: Double = 0
     let err = CH3.edgeLengthM(edge, &length)
-    precondition(err == 0, "edgeLengthM failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return length
 }
 
-public func edgeLengthRads(edge: UInt64) -> Double {
+public func edgeLengthRads(edge: UInt64) throws -> Double {
     var length: Double = 0
     let err = CH3.edgeLengthRads(edge, &length)
-    precondition(err == 0, "edgeLengthRads failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return length
 }
 
-public func getNumCells(res: Int32) -> Int64 {
+public func getNumCells(res: Int32) throws -> Int64 {
     var count: Int64 = 0
     let err = CH3.getNumCells(res, &count)
-    precondition(err == 0, "getNumCells failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return count
 }
 
-public func getRes0Cells() -> [UInt64] {
-    let count = getRes0CellCount()
+public func getRes0Cells() throws -> [UInt64] {
+    let count = try getRes0CellCount()
     var output = [UInt64](repeating: 0, count: count)
     let err = output.withUnsafeMutableBufferPointer {
         CH3.getRes0Cells($0.baseAddress)
     }
-    precondition(err == 0, "getRes0Cells failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return output
 }
 
-public func getRes0CellCount() -> Int {
+public func getRes0CellCount() throws -> Int {
     return Int(CH3.res0CellCount())
 }
 
-public func getPentagons(res: Int32) -> [UInt64] {
-    var output = [UInt64](repeating: 0, count: pentagonCount())
+public func getPentagons(res: Int32) throws -> [UInt64] {
+    var output = [UInt64](repeating: 0, count: try pentagonCount())
     let err = output.withUnsafeMutableBufferPointer {
         CH3.getPentagons(res, $0.baseAddress)
     }
-    precondition(err == 0, "getPentagons failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return output
 }
 
-public func pentagonCount() -> Int {
+public func pentagonCount() throws -> Int {
     return Int(CH3.pentagonCount())
 }
 
-public func greatCircleDistanceKm(a: LatLng, b: LatLng) -> Double {
+public func greatCircleDistanceKm(a: LatLng, b: LatLng) throws -> Double {
     withUnsafePointer(to: a) { pa in
         withUnsafePointer(to: b) { pb in
             CH3.greatCircleDistanceKm(pa, pb)
@@ -133,7 +133,7 @@ public func greatCircleDistanceKm(a: LatLng, b: LatLng) -> Double {
     }
 }
 
-public func greatCircleDistanceM(a: LatLng, b: LatLng) -> Double {
+public func greatCircleDistanceM(a: LatLng, b: LatLng) throws -> Double {
     withUnsafePointer(to: a) { pa in
         withUnsafePointer(to: b) { pb in
             CH3.greatCircleDistanceM(pa, pb)
@@ -141,7 +141,7 @@ public func greatCircleDistanceM(a: LatLng, b: LatLng) -> Double {
     }
 }
 
-public func greatCircleDistanceRads(a: LatLng, b: LatLng) -> Double {
+public func greatCircleDistanceRads(a: LatLng, b: LatLng) throws -> Double {
     withUnsafePointer(to: a) { pa in
         withUnsafePointer(to: b) { pb in
             CH3.greatCircleDistanceRads(pa, pb)
@@ -149,7 +149,7 @@ public func greatCircleDistanceRads(a: LatLng, b: LatLng) -> Double {
     }
 }
 
-public func describeH3Error(err: Int32) -> String {
+public func describeH3Error(err: Int32) throws -> String {
     let error: H3Error = UInt32(err)
 
     guard let cStr = CH3.describeH3Error(error) else {

--- a/Sources/H3/H3.Traversal.swift
+++ b/Sources/H3/H3.Traversal.swift
@@ -1,14 +1,15 @@
 import CH3
 
-public func gridDistance(origin: UInt64, destination: UInt64) -> Int64 {
+public func gridDistance(origin: UInt64, destination: UInt64) throws -> Int64 {
     var distance: Int64 = 0
     let err = CH3.gridDistance(origin, destination, &distance)
-    precondition(err == 0, "gridDistance failed with error \(err)")
-    
+
+    try H3ErrorCode.throwOnError(err)
+
     return distance
 }
 
-public func gridRing(origin: UInt64, distance: Int) -> [UInt64] {
+public func gridRing(origin: UInt64, distance: Int) throws -> [UInt64] {
     guard distance > 0 else { return [origin] }
 
     let count = 6 * distance
@@ -16,12 +17,12 @@ public func gridRing(origin: UInt64, distance: Int) -> [UInt64] {
     let err = output.withUnsafeMutableBufferPointer {
         CH3.gridRing(origin, Int32(distance), $0.baseAddress)
     }
-    precondition(err == 0, "gridRing failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return output
 }
 
-public func gridRingUnsafe(origin: UInt64, distance: Int) -> [UInt64] {
+public func gridRingUnsafe(origin: UInt64, distance: Int) throws -> [UInt64] {
     guard distance > 0 else { return [origin] }
 
     let count = 6 * distance
@@ -29,52 +30,56 @@ public func gridRingUnsafe(origin: UInt64, distance: Int) -> [UInt64] {
     let err = output.withUnsafeMutableBufferPointer {
         CH3.gridRingUnsafe(origin, Int32(distance), $0.baseAddress)
     }
-    precondition(err == 0, "gridRing failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return output
 }
 
-public func maxGridRingSize(distance: Int) -> Int64 {
+public func maxGridRingSize(distance: Int) throws -> Int64 {
     var size: Int64 = 0
     let err = CH3.maxGridRingSize(Int32(distance), &size)
-    precondition(err == 0, "maxGridRingSize failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return size
 }
 
-public func gridDisk(origin: UInt64, distance: Int) -> [UInt64] {
-    let count = Int(maxGridDiskSize(distance: distance))
+public func gridDisk(origin: UInt64, distance: Int) throws -> [UInt64] {
+    let count = Int(try maxGridDiskSize(distance: distance))
     var output = [UInt64](repeating: 0, count: count)
 
     let err = output.withUnsafeMutableBufferPointer {
         CH3.gridDisk(origin, Int32(distance), $0.baseAddress)
     }
-    precondition(err == 0, "gridDisk failed with error \(err)")
-    
-    return output
-} 
+    try H3ErrorCode.throwOnError(err)
 
-public func maxGridDiskSize(distance: Int) -> Int64 {
+    return output
+}
+
+public func maxGridDiskSize(distance: Int) throws -> Int64 {
     var size: Int64 = 0
     let err = CH3.maxGridDiskSize(Int32(distance), &size)
-    precondition(err == 0, "maxGridDiskSize failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return size
 }
 
-public func gridDiskDistances(origin: UInt64, distance: Int) -> [[UInt64]] {
-    let count = Int(maxGridDiskSize(distance: distance))
+public func gridDiskDistances(origin: UInt64, distance: Int) throws
+    -> [[UInt64]]
+{
+    let count = Int(try maxGridDiskSize(distance: distance))
 
     var indexes = [UInt64](repeating: 0, count: count)
     var distances = [Int32](repeating: -1, count: count)
 
     let err = indexes.withUnsafeMutableBufferPointer { idxBuf in
         distances.withUnsafeMutableBufferPointer { distBuf in
-            CH3.gridDiskDistances(origin, Int32(distance), idxBuf.baseAddress, distBuf.baseAddress)
+            CH3.gridDiskDistances(
+                origin, Int32(distance), idxBuf.baseAddress, distBuf.baseAddress
+            )
         }
     }
 
-    precondition(err == 0, "gridDiskDistances failed")
+    try H3ErrorCode.throwOnError(err)
 
     var rings = Array(repeating: [UInt64](), count: distance + 1)
     for i in 0..<count {
@@ -86,54 +91,61 @@ public func gridDiskDistances(origin: UInt64, distance: Int) -> [[UInt64]] {
     return rings
 }
 
-public func gridDiskUnsafe(origin: UInt64, distance: Int) -> [UInt64] {
-    let count = Int(maxGridDiskSize(distance: distance))
+public func gridDiskUnsafe(origin: UInt64, distance: Int) throws -> [UInt64] {
+    let count = Int(try maxGridDiskSize(distance: distance))
     var output = [UInt64](repeating: 0, count: count)
 
     let err = output.withUnsafeMutableBufferPointer {
         CH3.gridDiskUnsafe(origin, Int32(distance), $0.baseAddress)
     }
-    precondition(err == 0, "gridDiskUnsafe failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return output
 }
 
-public func gridPathCells(start: UInt64, end: UInt64) -> [UInt64] {
-    let distance = gridPathCellsSize(start: start, end: end)
+public func gridPathCells(start: UInt64, end: UInt64) throws -> [UInt64] {
+    let distance = try gridPathCellsSize(start: start, end: end)
     let count = distance + 1
     var output = [UInt64](repeating: 0, count: count)
 
     let err = output.withUnsafeMutableBufferPointer {
         CH3.gridPathCells(start, end, $0.baseAddress)
     }
-    precondition(err == 0, "gridPathCells failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
 
     return output
 }
 
-public func gridPathCellsSize(start: UInt64, end: UInt64) -> Int {
+public func gridPathCellsSize(start: UInt64, end: UInt64) throws -> Int {
     var size: Int64 = 0
     let err = CH3.gridPathCellsSize(start, end, &size)
-    precondition(err == 0 && size >= 0, "gridPathCellsSize failed")
+    try H3ErrorCode.throwOnError(err)
+    if size < 0 {
+        throw H3ErrorCode.SizeInvalid
+    }
     return Int(size)
 }
 
-public func cellToLocalIJ(origin: UInt64, target: UInt64, mode: UInt32 = 0) -> CoordIJ {
+public func cellToLocalIJ(origin: UInt64, target: UInt64, mode: UInt32 = 0)
+    throws -> CoordIJ
+{
     var ij = CH3.CoordIJ(i: 0, j: 0)
     let err = withUnsafeMutablePointer(to: &ij) {
         CH3.cellToLocalIj(origin, target, mode, $0)
     }
-    precondition(err == 0, "cellToLocalIj failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
     return CoordIJ(i: ij.i, j: ij.j)
 }
 
-public func localIJToCell(origin: UInt64, ij: CoordIJ, mode: UInt32 = 0) -> UInt64 {
+public func localIJToCell(origin: UInt64, ij: CoordIJ, mode: UInt32 = 0) throws
+    -> UInt64
+{
     var result: UInt64 = 0
     var coord = CH3.CoordIJ(i: ij.i, j: ij.j)
     let err = withUnsafeMutablePointer(to: &coord) {
         CH3.localIjToCell(origin, $0, mode, &result)
     }
-    precondition(err == 0, "localIjToCell failed with error \(err)")
+    try H3ErrorCode.throwOnError(err)
     return result
 }
 

--- a/Sources/H3/H3.Vertexes.swift
+++ b/Sources/H3/H3.Vertexes.swift
@@ -1,31 +1,31 @@
 import CH3
 
-public func cellToVertex(cell: UInt64, vertexNum: Int) -> UInt64 {
+public func cellToVertex(cell: UInt64, vertexNum: Int) throws -> UInt64 {
     var vertex: UInt64 = 0
     let err = CH3.cellToVertex(cell, Int32(vertexNum), &vertex)
-    precondition(err == 0, "cellToVertex failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return vertex
 }
 
-public func cellToVertices(cell: UInt64) -> [UInt64] {
+public func cellToVertices(cell: UInt64) throws -> [UInt64] {
     var output = [UInt64](repeating: 0, count: 6)
     let err = output.withUnsafeMutableBufferPointer {
         CH3.cellToVertexes(cell, $0.baseAddress)
     }
-    precondition(err == 0, "cellToVertexes failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return output.filter { $0 != 0 }
 }
 
-public func vertexToLatLng(vertex: UInt64) -> LatLng {
+public func vertexToLatLng(vertex: UInt64) throws -> LatLng {
     var coord = LatLng(lat: 0, lng: 0)
     let err = CH3.vertexToLatLng(vertex, &coord)
-    precondition(err == 0, "vertexToLatLng failed with error \(err)")
-    
+    try H3ErrorCode.throwOnError(err)
+
     return coord
 }
 
-public func isValidVertex(vertex: UInt64) -> Bool {
+public func isValidVertex(vertex: UInt64) throws -> Bool {
     return CH3.isValidVertex(vertex) != 0
 }


### PR DESCRIPTION
Addresses https://github.com/JeremyEspresso/swift-h3/issues/6

This is a more-or-less direct translation between a C enum and a Swift enum that attempts to preserve the information available in the source code comments. It adds one new error code, SizeInvalid, to capture a few preconditions checking sizes. This may not be the best way to handle it, but it's better than a precondition for now.